### PR TITLE
added option to choose version rabbitmq and erlang.

### DIFF
--- a/rabbit-node.tf
+++ b/rabbit-node.tf
@@ -10,6 +10,8 @@ data "template_file" "rabbit-node" {
     ERL_SECRET_COOKIE = var.erl_secret_cookie
     AWS_ACCESS_KEY    = var.aws_access_key
     AWS_SECRET_KEY    = var.aws_secret_key
+    RABBITMQ_VERSION  = var.rabbitmq_version
+    ERLANG_VERSION    = var.erlang_version
     CLUSTER_NAME      = "${var.cluster_fqdn}-${var.name}-${var.environment}"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,16 @@ variable "rabbit_volume_size" {
   description = "Attached EBS volume size in GB - this is where docker data will be stored"
 }
 
+variable "rabbitmq_version" {
+  description = "The version of the rabbitmq that you want install. To see all versions click this link: https://dl.bintray.com/rabbitmq/debian/dists/"
+  default     = "main" # rabbitmq-server-v3.6.x, rabbitmq-server-v3.7.x, rabbitmq-server-v3.8.x/
+}
+
+variable "erlang_version" {
+  description = "The version of the rabbitmq that you want install. To see all versions click this link: https://dl.bintray.com/rabbitmq-erlang/debian/dists/"
+  default     = "erlang" # erlang-16.x, erlang-19.x, erlang-20.x, erlang-21.x, erlang-22.x
+}
+
 # ------------------------------------------------------
 #  Network - VPC  parameters
 # ------------------------------------------------------


### PR DESCRIPTION
Added option to choose version rabbitmq and erlang at the time of installation, inspired by official rabbitmq documentation. Because there are consumers that don't work with the last versions of the rabbitmq (3.8.0). 
IMPORTANT: The default versions of rabbitmq and erlang still are the most recents, look variables.tf file. :)